### PR TITLE
250115_Sungwoo

### DIFF
--- a/programmers/귤 고르기_sungwoo.java
+++ b/programmers/귤 고르기_sungwoo.java
@@ -1,0 +1,34 @@
+// 풀이시간: 15분
+
+import java.util.*;
+
+class Solution {
+    public int solution(int k, int[] tangerine) {
+
+        HashMap<Integer, Integer> map = new HashMap<>();  // 해쉬맵 활용 (key: 크기, value: 개수)
+
+        // 1. 귤 크기별로 개수를 저장
+        for (int i = 0; i < tangerine.length; i++)
+            map.put(tangerine[i], map.getOrDefault(tangerine[i], 0) + 1);
+
+        // 2. 리스트에 크기별 귤 개수(values)를 내림차순으로 저장
+        ArrayList<Integer> cntList = new ArrayList<>();
+
+        for (Integer key: map.keySet()) {
+            cntList.add(map.get(key));
+        }
+
+        cntList.sort(Comparator.reverseOrder());
+
+        // 3. 귤을 개수가 많은 크기부터 담으며 반복하며 종류의 최솟값을 구함
+        Iterator<Integer> cntIter = cntList.iterator();
+        int answer = 0;
+
+        while (k > 0) {  // 더 이상 담을 귤이 없을 때까지 반복
+            k -= cntIter.next();
+            answer++;
+        }
+
+        return answer;
+    }
+}

--- a/programmers/미로 탈출_sungwoo.java
+++ b/programmers/미로 탈출_sungwoo.java
@@ -1,0 +1,83 @@
+// 풀이 시간: 45분
+
+import java.util.*;
+
+class Solution {
+
+    class Node {  // 좌표와 비용(시간)을 담는 클래스
+        int x; int y;
+        int cost;
+        Node(int x, int y, int cost) {
+            this.x = x; this.y = y; this.cost = cost;
+        }
+    }
+
+    public int mazeSearch(char[][] maps) {  // BFS 수행 메서드
+
+        int M = maps.length; int N = maps[0].length;  // 가로/세로 크기
+        boolean[][] visited = new boolean[M][N];  // 방문 여부 확인용 배열
+        int[] dx = {1, -1, 0, 0};  // x, y 변화량
+        int[] dy = {0, 0, 1, -1};
+
+        // 1. find (x, y) of start, lever, end
+        int startX = -1, startY = -1; int leverX = -1, leverY = -1; int endX = -1, endY = -1;
+
+        for (int i = 0; i < M; i++) {
+            for (int j = 0; j < N; j++) {
+                if (maps[i][j] == 'S') {  // start point
+                    startX = i; startY = j;
+                } else if (maps[i][j] == 'L') {  // lever point
+                    leverX = i; leverY = j;
+                } else if (maps[i][j] == 'E') {  // end point
+                    endX = i; endY = j;
+                }
+            }
+        }
+
+        // 2. set up queue
+        Queue<Node> q = new LinkedList<>();  // 큐 생성
+        q.offer(new Node(startX, startY, 0));  // 시작점 삽입
+        visited[startX][startY] = true;  // 시작점 방문 체크
+        boolean leverVisit = false;  // 레버 방문 여부 (레버 방문 및 end 도달 시 종료하기 위함)
+        int cost = -1;
+
+        // 3. bfs
+        while(!q.isEmpty()) {
+
+            Node curNode = q.poll();
+
+            if (curNode.x == leverX && curNode.y == leverY) {  // 레버에 도달했다면, queue와 visited 초기화 후 end를 향해 이어서 탐색
+                visited = new boolean[M][N];
+                visited[leverX][leverY] = true;
+                q.clear();
+                leverVisit = true;  // 레버 방문 체크
+            }
+
+            if (leverVisit && curNode.x == endX && curNode.y == endY) {  // 출구
+                cost = curNode.cost;
+                break;
+            }
+
+            for(int i = 0; i < 4; i++) {  // 상하좌우 방향 탐색
+                int nx = curNode.x + dx[i];
+                int ny = curNode.y + dy[i];
+
+                if (nx >= 0 && nx < M && ny >= 0 && ny < N && maps[nx][ny] != 'X' && !visited[nx][ny]) {  // 위치 유효성 및 방문 여부 검사
+                    q.offer(new Node(nx, ny, curNode.cost + 1));
+                    visited[nx][ny] = true;
+                }
+            }
+        }
+
+        return cost;
+    }
+
+    public int solution(String[] maps) {
+        char[][] charMaps = new char[maps.length][];
+
+        for (int i = 0; i < maps.length; i++)  // char[][]로 변환 수행
+            charMaps[i] = maps[i].toCharArray();
+
+        return mazeSearch(charMaps);  // BFS 수행 및 결과 리턴
+    }
+}

--- a/programmers/숫자 변환하기_sungwoo.java
+++ b/programmers/숫자 변환하기_sungwoo.java
@@ -1,0 +1,31 @@
+// 풀이 시간: 32분
+
+import java.util.*;
+
+class Solution {
+    public int solution(int x, int y, int n) {
+
+        int[] dp = new int[y + 1];  // DP 테이블 생성 (i로의 변환을 위한 최소 연산 횟수를 담음)
+        Arrays.fill(dp, -1);  // -1로 채워 '변환 불가'를 기본값으로
+
+        dp[x] = 0;  // x로의 변환은 0회로 설정한 뒤 반복문 시작
+
+        for (int i = x + 1; i <= y; i++) {  // y로의 변환까지의 최소 연산 횟수를 DP로 계산
+
+            int tmp = Integer.MAX_VALUE;
+
+            // 3가지 경우의 수에 대해 '인덱스 유효성' 및 'num으로의 변환 가능 여부' 체크
+            if (i - n >= x && dp[i - n] != -1)
+                tmp = Math.min(tmp, dp[i - n] + 1);
+            if (i % 2 == 0 && dp[i / 2] >= 0)
+                tmp = Math.min(tmp, dp[i / 2] + 1);
+            if (i % 3 == 0 && dp[i / 3] >= 0)
+                tmp = Math.min(tmp, dp[i / 3] + 1);
+
+            if (tmp != Integer.MAX_VALUE)  // 변환 가능하다면 dp 값 업데이트
+                dp[i] = tmp;
+        }
+
+        return dp[y];
+    }
+}

--- a/programmers/이중우선순위큐_sungwoo1.java
+++ b/programmers/이중우선순위큐_sungwoo1.java
@@ -1,0 +1,34 @@
+// 풀이 시간: 18분
+
+import java.util.*;
+
+class Solution {
+    public int[] solution(String[] operations) {
+
+        LinkedList<Integer> list = new LinkedList<>();  // 링크드리스트 생성 (빠른 삽입/삭제)
+
+        for (String operation: operations) {
+
+            char o = operation.charAt(0);  // 명령어
+            Integer n = Integer.parseInt(operation.substring(2));  // 숫자
+
+            if (o == 'I') {  // I: 삽입
+                list.add(n);
+                list.sort(null);  // 삽입 시마다 정렬 수행 -> 팀소트: 이미 정렬된 리스트에 대해 O(n)
+            } else {  // D: 삭제
+                if (list.isEmpty())  // 큐가 비었으면 무시
+                    continue;
+
+                if (n == -1)  // 최솟값 삭제
+                    list.removeFirst();
+                else  // 최댓값 삭제
+                    list.removeLast();
+            }
+        }
+
+        if (list.isEmpty())  // 비어있으면 [0,0] 리턴
+            return new int[]{0, 0};
+
+        return new int[]{list.getLast(), list.getFirst()};  // [최댓값, 최솟값] 리턴
+    }
+}

--- a/programmers/이중우선순위큐_sungwoo2.java
+++ b/programmers/이중우선순위큐_sungwoo2.java
@@ -1,0 +1,44 @@
+// 1번 풀이는 sort를 여러 번 사용한다는 점 때문에 찝찝하여 더 나은 풀이를 찾아보았다.
+// 자바 다른 풀이의 경우, 최대힙과 최소힙을 이용하는 풀이가 다수 존재하여 시도하였으나,
+// remove() 메서드가 O(n)의 시간복잡도를 가지므로 의미가 없었다.
+
+// 가장 처음에 문제를 보고 TreeSet 사용하면 금방 풀릴 문제라고 생각했으나 중복을 허용하지 않는다는 점 때문에 TreeSet 사용하지 못했다.
+// 그러나, 파이썬 풀이 맨 위에 있는 풀이가 중복을 허용하는 Tree를 활용한 풀이로서, 가장 정석 풀이라고 생각된다. (최대/최소 탐색 및 삭제가 O(logn)이기 때문)
+
+import java.util.*;
+
+class Solution {
+    public int[] solution(String[] operations) {
+
+        PriorityQueue<Integer> pqAsc = new PriorityQueue<>();  // 최소힙
+        PriorityQueue<Integer> pqDesc = new PriorityQueue<>(Collections.reverseOrder());  // 최대힙
+
+        for (String operation: operations) {
+
+            char o = operation.charAt(0);  // 명령어
+            Integer n = Integer.parseInt(operation.substring(2));  // 숫자
+
+            if (o == 'I') {  // I: 삽입 -> 양 큐의 삽입
+                pqAsc.offer(n);
+                pqDesc.offer(n);
+            } else {  // D: 삭제
+                if (pqAsc.isEmpty())  // 하나의 큐가 비었다면 명령어 무시
+                    continue;
+
+                if (n == -1) { // 최솟값 삭제
+                    int tmp = pqAsc.poll();
+                    pqDesc.remove(tmp);  // 삭제된 값을 최대힙에서 삭제
+                }
+                else { // 최댓값 삭제
+                    int tmp = pqDesc.poll();
+                    pqAsc.remove(tmp);  // 삭제된 값을 최소힙에서 삭제
+                }
+            }
+        }
+
+        if (pqAsc.isEmpty())  // 비어있으면 [0,0] 리턴
+            return new int[]{0, 0};
+
+        return new int[]{pqDesc.poll(), pqAsc.poll()};  // [최댓값, 최솟값] 리턴
+    }
+}


### PR DESCRIPTION
### 이중우선순위큐 문제

가장 먼저 문제를 보고 TreeSet 사용하면 금방 풀릴 문제라고 생각했으나 중복을 허용하지 않는다는 점 때문에 TreeSet 사용하지 못했다.

따라서 삽입/삭제가 빠른 링크드리스트를 활용하기로 하였고, 최대/최소 탐색에 대해서는 팀소트의 '이미 정렬된 리스트에 대해서는 O(N)의 시간복잡도를 가진다'는 특징이 있으므로 이렇게 풀이하였다.

> 그럼에도 불구하고 문제에서의 연산이 최대 1,000,000번 수행될 수 있다는 점 때문에 더 나은 풀이를 찾아보았다.
자바 다른 풀이의 경우, 최대힙과 최소힙을 이용하는 풀이가 다수 존재하여 시도하였으나, remove() 메서드가 O(n)의 시간복잡도를 가지므로 의미가 없었다.
그러나, [여기](https://school.programmers.co.kr/learn/courses/30/lessons/42628/solution_groups?language=python3)에 맨 위 파이썬 풀이는 중복을 허용하는 트리를 직접 구현하여 활용한 풀이로서, 가장 정석 풀이라고 생각된다. (최대/최소 탐색 및 삭제가 O(logn)이기 때문)